### PR TITLE
Save data as uint8

### DIFF
--- a/nilearn/image/image.py
+++ b/nilearn/image/image.py
@@ -358,8 +358,6 @@ def difference_of_gaussian(fdata, affine, fwhmNarrow):
     fwhmNarrow : int
         Narrow kernel width, in millimeters. Is an arbitrary ratio of wide to narrow kernel.
             human cortex about 2.5mm thick
-            Marr and Hildreth (1980) suggest 1.6
-            Wilson and Giese (1977) suggest 1.5
             Large values yield smoother results
 
     Returns
@@ -368,13 +366,16 @@ def difference_of_gaussian(fdata, affine, fwhmNarrow):
 
     """
 
+    #Hardcode 1.6 as ratio of wide versus narrow FWHM
+    # Marr and Hildreth (1980) suggest narrow to wide ratio of 1.6
+    # Wilson and Giese (1977) suggest narrow to wide ratio of 1.5
     fwhmWide = fwhmNarrow * 1.6
     #optimization: we will use the narrow Gaussian as the input to the wide filter
     fwhmWide = math.sqrt((fwhmWide*fwhmWide) - (fwhmNarrow*fwhmNarrow));
     print('Narrow/Wide FWHM {} / {}'.format(fwhmNarrow, fwhmWide))
-    img25 = _smooth_array(fdata, affine, fwhmNarrow)
-    img40 = _smooth_array(img25, affine, fwhmWide)
-    img = img25 - img40
+    imgNarrow = _smooth_array(fdata, affine, fwhmNarrow)
+    imgWide = _smooth_array(imgNarrow, affine, fwhmWide)
+    img = imgNarrow - imgWide
     img = binary_zero_crossing(img)
     return img
 
@@ -402,9 +403,9 @@ def dog_img(img, fwhm):
     print(f'Input intensity range {np.nanmin(img)}..{np.nanmax(img)}')
     print(f'Image shape {img.shape[0]}x{img.shape[1]}x{img.shape[2]}')
 
-    dog_fdata = dehaze(img, 5)
+    dog_fdata = dehaze(img, 3)
     dog = difference_of_gaussian(dog_fdata, img.affine, fwhm)
-    out_img = new_img_like(img, dog, img.affine, copy_header=True)
+    out_img = new_img_like(img, dog, img.affine, copy_header=False)
     return out_img
 
 def _crop_img_to(img, slices, copy=True):


### PR DESCRIPTION
Anthony, 
  I made a couple of minor changes: using the default dehaze setting and using the `UINT8` datatype for binary data.

As described [here](https://www.biorxiv.org/content/10.1101/2022.09.14.507937v1) a nice feature of the DoG is that the adjustable parameters are spatial, which are known for most MRI modalities (e.g. voxel resolution set by SNR, thickness of human cortex), while filters like Canny uses intensity parameters which are not calibrated for most MRI modalities.

This demo compares the DoG (yellow) versus the nilearn Canny (red).  

```
from nilearn import plotting, image, datasets


# haxby dataset to have anatomical image, EPI images and masks
haxby_dataset = datasets.fetch_haxby()
haxby_anat_filename = haxby_dataset.anat[0]
anat_img = image.mean_img(haxby_anat_filename)

display = plotting.plot_anat(anat_img, dim=-.9, axes=None, threshold=40, draw_cross=False)


dog_anat_img = image.dog_img(anat_img, fwhm=3)
display.add_overlay(dog_anat_img, cmap=plotting.cm.alpha_cmap('y'), alpha=1)
display.add_edges(anat_img, color='r')
plotting.show()
```
![DoGrgb](https://user-images.githubusercontent.com/8930807/196236187-b155df10-d3c7-470b-9dff-b883fdcc72d2.png)

You can also save the edges to disk. Note that edges are computed in 3D so `edge` voxels are identical for coronal, sagittal and axial slices (unlike nilearn's 2D Canny filter). Note the DoG edge appears thicker when oblique with the edge surface, and thin when orthogonal.

```
from nilearn import image, datasets
import nibabel as nib
import os
haxby_dataset = datasets.fetch_haxby()
haxby_anat_filename = haxby_dataset.anat[0]
anat_img = image.mean_img(haxby_anat_filename)
dog_anat_img = image.dog_img(anat_img, fwhm=3)
nib.save(dog_anat_img, os.path.join('build', 'test_dog.nii.gz')) 
```